### PR TITLE
Add tox and build server configuration, add badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+install:
+  - pip install virtualenv
+script:
+  - python --version
+  - python setup.py -q install
+  - python setup.py test

--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ Development Lead
 Patches and Contributions
 `````````````````````````
 - Naoko Reeves
+- Peter Bittner <django@bittner.it>

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst
 include LICENSE
+include requirements.txt

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,7 @@
-Eve-Swagger
-===========
+Eve-Swagger |latest-version|
+============================
+
+|build-status| |health| |python-support| |downloads| |license|
 
 Swagger_ extension for Eve_ powered RESTful APIs.
 
@@ -48,7 +50,27 @@ Installation
 
 Copyright
 ---------
-Cerberus is an open source project by `Nicola Iarocci`_. See the original LICENSE_ for more informations.
+Eve-Swagger is an open source project by `Nicola Iarocci`_.
+See the original LICENSE_ for more informations.
+
+.. |latest-version| image:: https://img.shields.io/pypi/v/eve-swagger.svg
+   :alt: Latest version on PyPI
+   :target: https://pypi.python.org/pypi/eve-swagger
+.. |build-status| image:: https://travis-ci.org/nicolaiarocci/eve-swagger.svg?branch=master
+   :alt: Build status
+   :target: https://travis-ci.org/nicolaiarocci/eve-swagger
+.. |health| image:: https://landscape.io/github/nicolaiarocci/eve-swagger/master/landscape.svg?style=flat
+   :target: https://landscape.io/github/nicolaiarocci/eve-swagger/master
+   :alt: Code health
+.. |python-support| image:: https://img.shields.io/pypi/pyversions/eve-swagger.svg
+   :target: https://pypi.python.org/pypi/eve-swagger
+   :alt: Python versions
+.. |downloads| image:: https://img.shields.io/pypi/dm/eve-swagger.svg
+   :alt: Monthly downloads from PyPI
+   :target: https://pypi.python.org/pypi/eve-swagger
+.. |license| image:: https://img.shields.io/pypi/l/eve-swagger.svg
+   :alt: Software license
+   :target: https://github.com/nicolaiarocci/eve-swagger/blob/master/LICENSE
 
 .. _Swagger: http://swagger.io/
 .. _Eve: http://python-eve.org/

--- a/eve_swagger/paths.py
+++ b/eve_swagger/paths.py
@@ -13,6 +13,7 @@ from flask import current_app as app
 # TODO consider adding at least a 'schema' property to response objects
 # TODO take auth into consideration
 
+
 def paths():
     paths = OrderedDict()
     for rd in app.config['DOMAIN'].values():

--- a/setup.py
+++ b/setup.py
@@ -10,12 +10,13 @@ from setuptools.command.test import test as TestCommand  # noqa N812
 
 def read_file(filename):
     """Read the contents of a file located relative to setup.py"""
-    with open(join(abspath(dirname(__file__)), filename)) as file:
-        return file.read()
+    with open(join(abspath(dirname(__file__)), filename)) as thefile:
+        return thefile.read()
 
 
 class Tox(TestCommand):
     """Integration of tox via the setuptools ``test`` command"""
+    # pylint: disable=attribute-defined-outside-init
     user_options = [('tox-args=', 'a', "Arguments to pass to tox")]
 
     def initialize_options(self):
@@ -28,7 +29,7 @@ class Tox(TestCommand):
         self.test_suite = True
 
     def run_tests(self):
-        from tox import cmdline
+        from tox import cmdline  # pylint: disable=import-error
         args = self.tox_args
         if args:
             args = split(self.tox_args)

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,53 @@
 #!/usr/bin/env python
-
+"""
+Setup for Swagger extension for Eve powered RESTful APIs
+"""
+from os.path import abspath, dirname, join
+from shlex import split
 from setuptools import setup, find_packages
+from setuptools.command.test import test as TestCommand  # noqa N812
 
-DESCRIPTION = ("Swagger extension for Eve powered RESTful APIs")
-LONG_DESCRIPTION = open('README.rst').read()
+
+def read_file(filename):
+    """Read the contents of a file located relative to setup.py"""
+    with open(join(abspath(dirname(__file__)), filename)) as file:
+        return file.read()
+
+
+class Tox(TestCommand):
+    """Integration of tox via the setuptools ``test`` command"""
+    user_options = [('tox-args=', 'a', "Arguments to pass to tox")]
+
+    def initialize_options(self):
+        TestCommand.initialize_options(self)
+        self.tox_args = None
+
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        from tox import cmdline
+        args = self.tox_args
+        if args:
+            args = split(self.tox_args)
+        errno = cmdline(args=args)
+        exit(errno)
+
 
 setup(
     name='Eve-Swagger',
     version='0.0.5.dev0',
-    description=DESCRIPTION,
-    long_description=LONG_DESCRIPTION,
+    description='Swagger extension for Eve powered RESTful APIs',
+    long_description=read_file('README.rst'),
     author='Nicola Iarocci',
     author_email='nicola@nicolaiarocci.com',
-    url='http://github.com/nicolaiarocci/cerberus',
-    license=open('LICENSE').read(),
+    url='http://github.com/nicolaiarocci/eve-swagger',
+    license='BSD',
     platforms=["any"],
     packages=find_packages(),
-    install_requires=['eve'],
+    install_requires=read_file('requirements.txt'),
     keywords=['swagger', 'eve', 'rest', 'api'],
     classifiers=[
         'Development Status :: 3 - Alpha',
@@ -35,4 +66,8 @@ setup(
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy'
     ],
+    tests_require=['tox'],
+    cmdclass={
+        'test': Tox,
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,7 @@ class Tox(TestCommand):
         args = self.tox_args
         if args:
             args = split(self.tox_args)
-        errno = cmdline(args=args)
-        exit(errno)
+        cmdline(args=args)
 
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[flake8]
+exclude = build,dist,reports,*.egg-info
+
+[pylint]
+disable = locally-disabled
+output-format = colorized
+reports = no
+
+[tox]
+envlist =
+    flake8
+    pylint
+
+[testenv:flake8]
+deps = flake8
+commands = flake8
+
+[testenv:pylint]
+deps = pylint
+commands =
+  - pylint --rcfile=tox.ini setup.py eve_swagger/


### PR DESCRIPTION
This PR adds configuration of Tox and Travis CI with static code analysis for now.

* Add test infrastructure integration (Tox, Travis CI)
* Add beautiful badges to README
* Avoid redundancy by including `requirements.txt` in `setup.py`

Required for all badges to work:

1. Activate this repository on [Travis CI](https://travis-ci.org/nicolaiarocci/eve-swagger)
1. Activate this repository on [Landscape](https://landscape.io/github/nicolaiarocci/eve-swagger) (create account?)

**NOTE:** PyLint does complain,  mainly about missing docstrings and argument names, but this does not fail the build (due to the `-` minus sign in front of the `pylint` command in `tox.ini`). You should remove the minus sign after fixing the issues in the affected modules.