### PR TITLE
Remove comma that raise error

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ Usage
             'name': 'BSD',
             'url': 'https://github.com/nicolaiarocci/eve-swagger/blob/master/LICENSE',
         }
-    },
+    }
 
     # optional. Will use flask.request.host if missing.
     app.config['SWAGGER_HOST'] = 'myhost.com'


### PR DESCRIPTION
    cerberus.cerberus.ValidationError: '({'description': 'an API description', 'termsOfService': 'my terms of service', 'contact': {'url': 'http://nicolaiarocci.com', 'name': 'nicola'}, 'version': '1.0', 'license': {'url': 'https://github.com/nicolaiarocci/eve-swagger/blob/master/LICENSE', 'name': 'BSD'}, 'title': 'My Supercool API'},)' is not a document, must be a dict