### PR TITLE
Create additional documentation at runtime

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Usage
 .. code-block:: python
 
     from eve import Eve
-    from eve_swagger import swagger
+    from eve_swagger import swagger, add_documentation
 
     app = Eve()
     app.register_blueprint(swagger)
@@ -33,6 +33,17 @@ Usage
 
     # optional. Will use flask.request.host if missing.
     app.config['SWAGGER_HOST'] = 'myhost.com'
+
+    # optional. Add/Update elements in the documentation at run-time without deleting subtrees.
+    add_documentation({'paths': {'/status': {'get': {'parameters': [
+        {
+            'in': 'query',
+            'name': 'foobar',
+            'required': False,
+            'description': 'special query parameter',
+            'type': 'string'
+        }]
+    }}}})
 
     if __name__ == '__main__':
         app.run()

--- a/eve_swagger/__init__.py
+++ b/eve_swagger/__init__.py
@@ -7,7 +7,7 @@
     :copyright: (c) 2015 by Nicola Iarocci.
     :license: BSD, see LICENSE for more details.
 """
-from .swagger import swagger  # noqa
+from .swagger import swagger, add_documentation  # noqa
 
 INFO = 'SWAGGER_INFO'
 HOST = 'SWAGGER_HOST'

--- a/eve_swagger/swagger.py
+++ b/eve_swagger/swagger.py
@@ -20,8 +20,10 @@ from .paths import paths
 swagger = Blueprint('eve_swagger', __name__)
 swagger.additional_documentation = OrderedDict()
 
+
 def add_documentation(doc):
     _nested_update(swagger.additional_documentation, doc)
+
 
 @swagger.route('/api-docs')
 def index():
@@ -50,6 +52,7 @@ def index():
 
     return jsonify(root)
 
+
 # https://stackoverflow.com/questions/3232943/update-value-of-a-nested-dictionary-of-varying-depth/18394648#comment41407580_18394648
 def _nested_update(orig_dict, new_dict):
     for key, val in new_dict.iteritems():
@@ -61,4 +64,3 @@ def _nested_update(orig_dict, new_dict):
         else:
             orig_dict[key] = new_dict[key]
     return orig_dict
-

--- a/eve_swagger/swagger.py
+++ b/eve_swagger/swagger.py
@@ -7,7 +7,7 @@
     :copyright: (c) 2015 by Nicola Iarocci.
     :license: BSD, see LICENSE for more details.
 """
-from collections import OrderedDict
+from collections import OrderedDict, Mapping
 from flask import Blueprint, jsonify
 
 from .definitions import definitions
@@ -18,7 +18,10 @@ from .paths import paths
 
 
 swagger = Blueprint('eve_swagger', __name__)
+swagger.additional_documentation = OrderedDict()
 
+def add_documentation(doc):
+    _nested_update(swagger.additional_documentation, doc)
 
 @swagger.route('/api-docs')
 def index():
@@ -43,4 +46,19 @@ def index():
     node(root, 'tags', tags())
     node(root, 'externalDocs', external_docs())
 
+    _nested_update(root, swagger.additional_documentation)
+
     return jsonify(root)
+
+# https://stackoverflow.com/questions/3232943/update-value-of-a-nested-dictionary-of-varying-depth/18394648#comment41407580_18394648
+def _nested_update(orig_dict, new_dict):
+    for key, val in new_dict.iteritems():
+        if isinstance(val, Mapping):
+            tmp = _nested_update(orig_dict.get(key, {}), val)
+            orig_dict[key] = tmp
+        elif isinstance(val, list):
+            orig_dict[key] = (orig_dict.get(key, []) + val)
+        else:
+            orig_dict[key] = new_dict[key]
+    return orig_dict
+

--- a/eve_swagger/swagger.py
+++ b/eve_swagger/swagger.py
@@ -53,7 +53,6 @@ def index():
     return jsonify(root)
 
 
-# https://stackoverflow.com/questions/3232943/update-value-of-a-nested-dictionary-of-varying-depth/18394648#comment41407580_18394648
 def _nested_update(orig_dict, new_dict):
     for key, val in new_dict.iteritems():
         if isinstance(val, Mapping):


### PR DESCRIPTION
This PR makes it possible to modify the swagger documentation non-destructively. That can be useful if you have a special endpoint that you want to change the documentation for.

```python
from eve_swagger import swagger, add_documentation
...
app.register_blueprint(swagger)
add_documentation({'info': {'title': 'foobar'}})  # replace title
add_documentation({'schemes': ['asdf']})   # add element to list 
add_documentation({'info': {'foo': 'bar'}})  # add element to dict

# add a query parameter
add_documentation({'paths': {'/status': {'get': {'parameters': [
    {
        'in': 'query',
        'name': 'foobar',
        'required': False,
        'description': 'special query parameter',
        'type': 'string'
    }]
}}}})
```

Please let me know what should be done differently.
(Is the stackoverflow reference in swagger.py necessary?)
