### PR TITLE
Properly defining floats

### DIFF
--- a/eve_swagger/definitions.py
+++ b/eve_swagger/definitions.py
@@ -52,6 +52,9 @@ def _type_and_format(rules):
 
     type = map.get(eve_type, (eve_type,))
 
+    if 'description' in rules:
+        resp['description'] = rules['description']
+
     resp['type'] = type[0]
     if type[0] == 'object':
         # we don't support 'valueschema' rule

--- a/eve_swagger/definitions.py
+++ b/eve_swagger/definitions.py
@@ -65,6 +65,10 @@ def _type_and_format(rules):
             # 'items' is mandatory for swagger, we assume it's a list of
             # strings
             resp['items'] = {'type': 'string'}
+    # floats in swagger are defined as type: number, format: float
+    elif type[0] == 'float':
+        resp['type'] = 'number'
+        resp['format'] = 'float'
     else:
         try:
             resp['format'] = type[1]


### PR DESCRIPTION
Scratching my own itch (#13), in a hacky way...

Also add swagger "description" fields to attributes, albeit also hacky.  Proper support should be included in Cerberus more likely.  Right now I'm adding a "description" attribute on the validation rules in settings.py in Eve.