### PR TITLE
Additional fields and resource-level description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,20 +64,24 @@ Description fields on the swagger docs
 --------------------------------------
 
 If you would like to include description fields to your swagger docs you can
-include a description field in your schema validations in your `settings.py`
+include a description field in your schema validations in your `settings.py`.
+This can be done per field as well as on the resource-level.
 
 As an example:
 
 .. code-block:: python
 
-   ...
-    'userName': {
-        'description': 'The username of the logged in user.',
-        'type': 'string',
-        'minlength': 1,
-        'maxlength': 256,
-        'required': True
-    },
+    ...
+    'description': 'Description of the user resource',
+    'schema': {
+        'userName': {
+            'description': 'The username of the logged in user.',
+            'type': 'string',
+            'minlength': 1,
+            'maxlength': 256,
+            'required': True
+        },
+    }
     ...
     
 **NOTE**: If you do use that feature make sure that the `TRANSPARENT_SCHEMA_RULES`

--- a/eve_swagger/definitions.py
+++ b/eve_swagger/definitions.py
@@ -27,7 +27,7 @@ def _object(schema):
         if rules.get('required') is True:
             required.append(field)
 
-        props[field] = _type_and_format(rules)
+        props[field] = _field_props(rules)
 
     field_def = {}
     field_def['type'] = 'object'
@@ -37,7 +37,7 @@ def _object(schema):
     return field_def
 
 
-def _type_and_format(rules):
+def _field_props(rules):
     resp = {}
     map = {
         'dict': ('object',),
@@ -54,6 +54,32 @@ def _type_and_format(rules):
     if 'description' in rules:
         resp['description'] = rules['description']
 
+    if 'allowed' in rules:
+        resp['enum'] = rules['allowed']
+
+    if 'default' in rules:
+        resp['default'] = rules['default']
+
+    if 'minlength' in rules:
+        if eve_type == 'string':
+            resp['minLength'] = rules['minlength']
+        elif eve_type == 'list':
+            resp['minItems'] = rules['minlength']
+
+    if 'maxlength' in rules:
+        if eve_type == 'string':
+            resp['maxLength'] = rules['maxlength']
+        elif eve_type == 'list':
+            resp['maxItems'] = rules['maxlength']
+
+    if 'min' in rules:
+        if eve_type in ['number', 'integer', 'float']:
+            resp['minimum'] = rules['min']
+
+    if 'max' in rules:
+        if eve_type in ['number', 'integer', 'float']:
+            resp['maximum'] = rules['max']
+
     type = map.get(eve_type, (eve_type,))
 
     resp['type'] = type[0]
@@ -64,7 +90,7 @@ def _type_and_format(rules):
     elif type[0] == 'array':
         type = 'array'
         if 'schema' in rules:
-            resp['items'] = _type_and_format(rules['schema'])
+            resp['items'] = _field_props(rules['schema'])
         else:
             # 'items' is mandatory for swagger, we assume it's a list of
             # strings

--- a/eve_swagger/definitions.py
+++ b/eve_swagger/definitions.py
@@ -16,6 +16,8 @@ def definitions():
     for rd in app.config['DOMAIN'].values():
         title = rd['item_title']
         definitions[title] = _object(rd['schema'])
+        if 'description' in rd:
+            definitions[title]['description'] = rd['description']
 
     return definitions
 


### PR DESCRIPTION
This PR translates more of the eve fields to their corresponding swagger fields.
PR #15 is extended by adding resource-level description.
I renamed `_type_and_format`, because now more fields are set in this function.