### PR TITLE
Option to disable resource documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,23 @@ As an example:
 in your `settings.py` is also turned ON, otherwise you will get complains from the
 Cerberus library about "unknown field 'description' for field [yourFieldName]"
 
+Disabling the documentation of a resource
+-----------------------------------------
+
+You can disable the documentation of a specific resource by adding a `disable_documentation` field
+to the resource definition in `settings.py`. This means that the resource will not show up in
+the `paths` or `definitions` sections of the swagger docs.
+
+.. code-block:: python
+
+    ...
+    'person': {
+        'item_title': 'person',
+        'disable_documentation': True,
+        'schema': {...}
+    }
+    ...
+
 Copyright
 ---------
 Eve-Swagger is an open source project by `Nicola Iarocci`_.

--- a/eve_swagger/definitions.py
+++ b/eve_swagger/definitions.py
@@ -14,6 +14,8 @@ from flask import current_app as app
 def definitions():
     definitions = OrderedDict()
     for rd in app.config['DOMAIN'].values():
+        if rd.get('disable_documentation'):
+            continue
         title = rd['item_title']
         definitions[title] = _object(rd['schema'])
         if 'description' in rd:

--- a/eve_swagger/paths.py
+++ b/eve_swagger/paths.py
@@ -17,6 +17,8 @@ from flask import current_app as app
 def paths():
     paths = OrderedDict()
     for rd in app.config['DOMAIN'].values():
+        if rd.get('disable_documentation'):
+            continue
         methods = rd['resource_methods']
         if methods:
             url = '/%s' % rd['url']


### PR DESCRIPTION
This PR adds an option to the resource definition in `settings.py` to disable the documentation of a specific resource. This means that the resource does not show up in the `paths` or `definitions` sections of the swagger doc.
```python
people = {
    'disable_documentation': True,
    'schema': {...}
}
```