### PR TITLE
Moved path parameters to a separate section

### DIFF
--- a/eve_swagger/objects.py
+++ b/eve_swagger/objects.py
@@ -65,7 +65,35 @@ def produces():
 
 
 def parameters():
-    pass
+    parameters = OrderedDict()
+    for (resource_name, rd) in app.config['DOMAIN'].items():
+        if resource_name.endswith('_versions'):
+            continue
+
+        title = rd['item_title']
+        lookup_field = rd['item_lookup_field']
+        eve_type = rd['schema'][lookup_field]['type']
+        descr = rd['schema'][lookup_field].get('description') or ''
+
+        p = OrderedDict()
+        p['in'] = 'path'
+        p['name'] = title.lower() + 'Id'
+        p['required'] = True
+        p['description'] = descr
+        p['type'] = eve_type
+        if eve_type == 'objectid':
+            p['type'] = 'string'
+            p['format'] = 'objectid'
+        elif eve_type == 'datetime':
+            p['type'] = 'string'
+            p['format'] = 'date-time'
+        elif eve_type == 'float':
+            p['type'] = 'number'
+            p['format'] = 'float'
+
+        parameters[title+'_'+lookup_field] = p
+
+    return parameters
 
 
 def responses():

--- a/eve_swagger/objects.py
+++ b/eve_swagger/objects.py
@@ -67,7 +67,8 @@ def produces():
 def parameters():
     parameters = OrderedDict()
     for (resource_name, rd) in app.config['DOMAIN'].items():
-        if resource_name.endswith('_versions'):
+        if (resource_name.endswith('_versions')
+                or rd.get('disable_documentation')):
             continue
 
         title = rd['item_title']

--- a/eve_swagger/paths.py
+++ b/eve_swagger/paths.py
@@ -28,7 +28,7 @@ def paths():
         if methods:
             item_id = '%sId' % rd['item_title'].lower()
             url = '/%s/{%s}' % (rd['url'], item_id)
-            paths[url] = _item(rd, methods, item_id)
+            paths[url] = _item(rd, methods)
     return paths
 
 
@@ -43,16 +43,16 @@ def _resource(rd, methods):
     return item
 
 
-def _item(rd, methods, item_id):
+def _item(rd, methods):
     item = OrderedDict()
     if 'GET' in methods:
-        item['get'] = getitem_response(rd, item_id)
+        item['get'] = getitem_response(rd)
     if 'PUT' in methods:
-        item['put'] = put_response(rd, item_id)
+        item['put'] = put_response(rd)
     if 'PATCH' in methods:
-        item['patch'] = patch_response(rd, item_id)
+        item['patch'] = patch_response(rd)
     if 'DELETE' in methods:
-        item['delete'] = deleteitem_response(rd, item_id)
+        item['delete'] = deleteitem_response(rd)
     return item
 
 
@@ -98,7 +98,7 @@ def delete_response(rd):
     ])
 
 
-def getitem_response(rd, item_id):
+def getitem_response(rd):
     title = rd['item_title']
     return OrderedDict([
         ('summary', 'Retrieves a %s document' % title),
@@ -109,11 +109,11 @@ def getitem_response(rd, item_id):
             },
 
         }),
-        ('parameters', [id_parameter(item_id, rd)])
+        ('parameters', [id_parameter(rd)])
     ])
 
 
-def put_response(rd, item_id):
+def put_response(rd):
     title = rd['item_title']
     return OrderedDict([
         ('summary', 'Replaces a %s document' % title),
@@ -122,11 +122,11 @@ def put_response(rd, item_id):
                 'description': '%s document replaced successfully' % title
             }
         }),
-        ('parameters', [id_parameter(item_id, rd), get_parameters(rd)])
+        ('parameters', [id_parameter(rd), get_parameters(rd)])
     ])
 
 
-def patch_response(rd, item_id):
+def patch_response(rd):
     title = rd['item_title']
     return OrderedDict([
         ('summary', 'Updates a %s document' % title),
@@ -135,11 +135,11 @@ def patch_response(rd, item_id):
                 'description': '%s document updated successfully' % title
             }
         }),
-        ('parameters', [id_parameter(item_id, rd), get_parameters(rd)])
+        ('parameters', [id_parameter(rd), get_parameters(rd)])
     ])
 
 
-def deleteitem_response(rd, item_id):
+def deleteitem_response(rd):
     title = rd['item_title']
     return OrderedDict([
         ('summary', 'Deletes a %s document' % title),
@@ -148,10 +148,10 @@ def deleteitem_response(rd, item_id):
                 'description': '%s document deleted successfully' % title
             }
         }),
-        ('parameters', [id_parameter(item_id, rd)])
+        ('parameters', [id_parameter(rd)])
     ])
 
 
-def id_parameter(item_id, rd):
+def id_parameter(rd):
     return {'$ref': '#/parameters/{}_{}'.format(rd['item_title'],
                                                 rd['item_lookup_field'])}

--- a/eve_swagger/paths.py
+++ b/eve_swagger/paths.py
@@ -153,12 +153,5 @@ def deleteitem_response(rd, item_id):
 
 
 def id_parameter(item_id, rd):
-    return OrderedDict([
-        ('in', 'path'),
-        ('name', item_id),
-        ('required', True),
-        ('description', 'ID of the %s' %
-         rd['item_title']),
-        ('type', 'string'),
-        ('format', 'objectid')
-    ])
+    return {'$ref': '#/parameters/{}_{}'.format(rd['item_title'],
+                                                rd['item_lookup_field'])}


### PR DESCRIPTION
This PR moves the path parameters (`/people/{personId}`) to their own section of the swagger doc.
That cleans up the `parameters` entries in the `paths` sections by referencing the parameters.

```python
"paths": {
    "/people/{personId}": {
        "get": {
            ...
            "parameters": [
                {"$ref": "#/parameters/person_id"}
            ]
        },
        "patch": {
            ...
            "parameters": [
                {"$ref": "#/parameters/person_id"}
            ]
        }
    }
},
...
"parameters": {
    "person_id": {
        "in": "path",
        "name": "personId",
        "type": "string",
        "required": True,
        "description": "The ID of a person"
    }
}
```
