### PR TITLE
Restore Python3 Compatibility

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Patches and Contributions
 - Peter Bittner <django@bittner.it>
 - Stratos Gerakakis <stratosgear@gmail.com>
 - otibsa
+- Matthew Ellison

--- a/eve_swagger/swagger.py
+++ b/eve_swagger/swagger.py
@@ -54,7 +54,7 @@ def index():
 
 
 def _nested_update(orig_dict, new_dict):
-    for key, val in new_dict.iteritems():
+    for key, val in new_dict.items():
         if isinstance(val, Mapping):
             tmp = _nested_update(orig_dict.get(key, {}), val)
             orig_dict[key] = tmp


### PR DESCRIPTION
There doesn't appear to be a reason for using `iteritems` here considering that `new_dict` is not being modified. Replaced with `items` to make it compatible with Python 3.