### PR TITLE
Add test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,9 @@ env:
   - TOX_ENV=flake8
 script:
   - tox -e $TOX_ENV
+services:
+  - mongodb
+before-script:
+  # Timer: https://docs.travis-ci.com/user/database-setup/#MongoDB-does-not-immediately-accept-connections
+  - sleep 15
+  - mongo eve_swagger_test --eval 'db.addUser("test_user", "test_pw");'

--- a/eve_swagger/__init__.py
+++ b/eve_swagger/__init__.py
@@ -7,6 +7,10 @@
     :copyright: (c) 2015 by Nicola Iarocci.
     :license: BSD, see LICENSE for more details.
 """
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict  # noqa: F401
 from .swagger import swagger, add_documentation  # noqa
 
 INFO = 'SWAGGER_INFO'

--- a/eve_swagger/definitions.py
+++ b/eve_swagger/definitions.py
@@ -47,7 +47,7 @@ def _object(rd, dr_sources):
             # replace None in dr_sources with the field properties
             dr_sources[def_name] = OrderedDict(props[field])
 
-            props[field] = {'$ref': '#/definitions/{}'.format(def_name)}
+            props[field] = {'$ref': '#/definitions/{0}'.format(def_name)}
 
         if 'data_relation' in rules:
             # the current field is a copy of another field
@@ -57,7 +57,9 @@ def _object(rd, dr_sources):
                 continue
             title = app.config['DOMAIN'][dr['resource']]['item_title']
             source_def_name = title+'_'+dr['field']
-            props[field] = {'$ref': '#/definitions/{}'.format(source_def_name)}
+            props[field] = {
+                '$ref': '#/definitions/{0}'.format(source_def_name)
+            }
 
     field_def = {}
     field_def['type'] = 'object'

--- a/eve_swagger/definitions.py
+++ b/eve_swagger/definitions.py
@@ -7,8 +7,9 @@
     :copyright: (c) 2016 by Nicola Iarocci.
     :license: BSD, see LICENSE for more details.
 """
-from collections import OrderedDict
 from flask import current_app as app
+
+from eve_swagger import OrderedDict
 
 
 def definitions():

--- a/eve_swagger/objects.py
+++ b/eve_swagger/objects.py
@@ -7,11 +7,11 @@
     :copyright: (c) 2015 by Nicola Iarocci.
     :license: BSD, see LICENSE for more details.
 """
-from collections import OrderedDict
 from eve.utils import api_prefix
 from flask import request, current_app as app
 
 import eve_swagger
+from eve_swagger import OrderedDict
 from .validation import validate_info
 
 

--- a/eve_swagger/objects.py
+++ b/eve_swagger/objects.py
@@ -90,7 +90,7 @@ def parameters():
 
             # copy description if necessary
             descr = descr or source_def.get('description')
-            descr = descr + ' (links to {})'.format(source_def_name)
+            descr = descr + ' (links to {0})'.format(source_def_name)
 
         p = OrderedDict()
         p['in'] = 'path'

--- a/eve_swagger/paths.py
+++ b/eve_swagger/paths.py
@@ -153,5 +153,5 @@ def deleteitem_response(rd):
 
 
 def id_parameter(rd):
-    return {'$ref': '#/parameters/{}_{}'.format(rd['item_title'],
-                                                rd['item_lookup_field'])}
+    return {'$ref': '#/parameters/{0}_{1}'.format(rd['item_title'],
+                                                  rd['item_lookup_field'])}

--- a/eve_swagger/paths.py
+++ b/eve_swagger/paths.py
@@ -7,7 +7,7 @@
     :copyright: (c) 2015 by Nicola Iarocci.
     :license: BSD, see LICENSE for more details.
 """
-from collections import OrderedDict
+from eve_swagger import OrderedDict
 from flask import current_app as app
 
 # TODO consider adding at least a 'schema' property to response objects

--- a/eve_swagger/swagger.py
+++ b/eve_swagger/swagger.py
@@ -7,9 +7,10 @@
     :copyright: (c) 2015 by Nicola Iarocci.
     :license: BSD, see LICENSE for more details.
 """
-from collections import OrderedDict, Mapping
+from collections import Mapping
 from flask import Blueprint, jsonify
 
+from eve_swagger import OrderedDict
 from .definitions import definitions
 from .objects import info, host, base_path, schemes, consumes, produces, \
     parameters, responses, security_definitions, security, tags, \

--- a/eve_swagger/tests/__init__.py
+++ b/eve_swagger/tests/__init__.py
@@ -8,6 +8,7 @@ from flask_pymongo import MongoClient
 from eve_swagger.tests.test_settings import MONGO_HOST, MONGO_PORT, \
     MONGO_USERNAME, MONGO_PASSWORD, MONGO_DBNAME
 
+
 class TestBase(unittest.TestCase):
     def setUp(self, settings=None):
         self.this_directory = os.path.dirname(os.path.realpath(__file__))

--- a/eve_swagger/tests/__init__.py
+++ b/eve_swagger/tests/__init__.py
@@ -1,4 +1,4 @@
-import unittest
+import sys
 import os
 import json
 
@@ -7,6 +7,11 @@ import eve_swagger
 from flask_pymongo import MongoClient
 from eve_swagger.tests.test_settings import MONGO_HOST, MONGO_PORT, \
     MONGO_USERNAME, MONGO_PASSWORD, MONGO_DBNAME
+
+if sys.version_info >= (2, 7):
+    import unittest  # noqa
+else:
+    import unittest2 as unittest  # noqa
 
 
 class TestBase(unittest.TestCase):

--- a/eve_swagger/tests/__init__.py
+++ b/eve_swagger/tests/__init__.py
@@ -53,7 +53,7 @@ class TestBase(unittest.TestCase):
 
     def parse_response(self, r):
         try:
-            v = json.loads(r.get_data())
-        except json.JSONDecodeError:
+            v = json.loads(r.get_data().decode('utf-8'))
+        except ValueError:
             v = None
         return v

--- a/eve_swagger/tests/__init__.py
+++ b/eve_swagger/tests/__init__.py
@@ -1,0 +1,58 @@
+import unittest
+import os
+import json
+
+import eve
+import eve_swagger
+from flask_pymongo import MongoClient
+from eve_swagger.tests.test_settings import MONGO_HOST, MONGO_PORT, \
+    MONGO_USERNAME, MONGO_PASSWORD, MONGO_DBNAME
+
+class TestBase(unittest.TestCase):
+    def setUp(self, settings=None):
+        self.this_directory = os.path.dirname(os.path.realpath(__file__))
+        if settings is None:
+            settings = os.path.join(self.this_directory, 'test_settings.py')
+
+        self.setupDB()
+
+        self.settings = settings
+        self.app = eve.Eve(settings=self.settings)
+
+        self.app.register_blueprint(eve_swagger.swagger)
+        self.app.config['SWAGGER_INFO'] = {
+            'title': 'Test eve-swagger',
+            'version': '0.0.1'
+        }
+
+        self.test_client = self.app.test_client()
+        self.domain = self.app.config['DOMAIN']
+
+        self.swagger_doc = self.get_swagger_doc()
+
+    def tearDown(self):
+        del self.app
+        self.dropDB()
+
+    def setupDB(self):
+        self.connection = MongoClient(MONGO_HOST, MONGO_PORT)
+        self.connection.drop_database(MONGO_DBNAME)
+        if MONGO_USERNAME:
+            self.connection[MONGO_DBNAME].add_user(MONGO_USERNAME,
+                                                   MONGO_PASSWORD)
+
+    def dropDB(self):
+        self.connection = MongoClient(MONGO_HOST, MONGO_PORT)
+        self.connection.drop_database(MONGO_DBNAME)
+        self.connection.close()
+
+    def get_swagger_doc(self):
+        r = self.test_client.get('/api-docs')
+        return self.parse_response(r)
+
+    def parse_response(self, r):
+        try:
+            v = json.loads(r.get_data())
+        except json.JSONDecodeError:
+            v = None
+        return v

--- a/eve_swagger/tests/test_settings.py
+++ b/eve_swagger/tests/test_settings.py
@@ -1,0 +1,23 @@
+MONGO_HOST = 'localhost'
+MONGO_PORT = 27017
+MONGO_USERNAME = 'test_user'
+MONGO_PASSWORD = 'test_pw'
+MONGO_DBNAME = 'eve_swagger_test'
+
+TRANSPARENT_SCHEMA_RULES = True
+RESOURCE_METHODS = ['GET', 'POST', 'DELETE']
+ITEM_METHODS= ['GET', 'PATCH', 'PUT', 'DELETE']
+
+DOMAIN = {
+    'people': {
+        'description': 'the people resource',
+        'schema': {
+            'name': {
+                'type': 'string',
+                'required': True,
+                'unique': True,
+                'description': 'the last name of the person'
+            },
+        }
+    }
+}

--- a/eve_swagger/tests/test_settings.py
+++ b/eve_swagger/tests/test_settings.py
@@ -6,7 +6,7 @@ MONGO_DBNAME = 'eve_swagger_test'
 
 TRANSPARENT_SCHEMA_RULES = True
 RESOURCE_METHODS = ['GET', 'POST', 'DELETE']
-ITEM_METHODS= ['GET', 'PATCH', 'PUT', 'DELETE']
+ITEM_METHODS = ['GET', 'PATCH', 'PUT', 'DELETE']
 
 DOMAIN = {
     'people': {

--- a/eve_swagger/tests/test_settings.py
+++ b/eve_swagger/tests/test_settings.py
@@ -11,6 +11,7 @@ ITEM_METHODS = ['GET', 'PATCH', 'PUT', 'DELETE']
 DOMAIN = {
     'people': {
         'description': 'the people resource',
+        'type': 'dict',
         'schema': {
             'name': {
                 'type': 'string',
@@ -18,6 +19,46 @@ DOMAIN = {
                 'unique': True,
                 'description': 'the last name of the person'
             },
+            'job': {
+                'type': 'string',
+                'required': True,
+                'unique': True,
+                'description': 'the job of the person'
+            }
+        }
+    },
+    'disabled_resource': {
+        'disable_documentation': True,
+        'type': 'dict',
+        'schema': {
+            'field_1': {'type': 'string'}
+        }
+    },
+    'dr_resource_1': {
+        'type': 'dict',
+        'item_lookup_field': 'copied_field_with_description',
+        'schema': {
+            'copied_field_with_description': {
+                'type': 'string',
+                'description': 'foobar copied_field',
+                'data_relation': {
+                    'resource': 'people',
+                    'field': 'job'
+                }
+            },
+        }
+    },
+    'dr_resource_2': {
+        'type': 'dict',
+        'item_lookup_field': 'copied_field_without_description',
+        'schema': {
+            'copied_field_without_description': {
+                'type': 'string',
+                'data_relation': {
+                    'resource': 'people',
+                    'field': 'job'
+                }
+            }
         }
     }
 }

--- a/eve_swagger/tests/tests.py
+++ b/eve_swagger/tests/tests.py
@@ -18,9 +18,9 @@ class TestFoobar(TestBase):
 
         self.assertIn('info', doc)
         self.assertIn('title', doc['info'])
-        self.assertIsInstance(doc['info']['title'], basestring)
+        self.assertTrue(isinstance(doc['info']['title'], u''.__class__))
         self.assertIn('version', doc['info'])
-        self.assertIsInstance(doc['info']['version'], basestring)
+        self.assertTrue(isinstance(doc['info']['version'], u''.__class__))
 
     def test_paths(self):
         doc = self.swagger_doc

--- a/eve_swagger/tests/tests.py
+++ b/eve_swagger/tests/tests.py
@@ -1,10 +1,3 @@
-if __name__ == '__main__':
-    import sys
-    import os
-    import unittest
-    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                                 '..', '..')))
-
 from eve_swagger.tests import TestBase
 
 
@@ -34,7 +27,3 @@ class TestFoobar(TestBase):
 
     def test_resource_description(self):
         pass
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/eve_swagger/tests/tests.py
+++ b/eve_swagger/tests/tests.py
@@ -7,6 +7,7 @@ if __name__ == '__main__':
 
 from eve_swagger.tests import TestBase
 
+
 class TestFoobar(TestBase):
     def test_doc_is_dict(self):
         doc = self.swagger_doc
@@ -26,9 +27,10 @@ class TestFoobar(TestBase):
 
         self.assertIn('paths', doc)
         self.assertIn('/'+self.domain['people']['url'], doc['paths'])
-        self.assertIn('/%s/{%sId}' % (self.domain['people']['url'],
-                                      self.domain['people']['item_title'].lower()),
-                      doc['paths'])
+        self.assertIn(
+            '/%s/{%sId}' % (self.domain['people']['url'],
+                            self.domain['people']['item_title'].lower()),
+            doc['paths'])
 
     def test_resource_description(self):
         pass

--- a/eve_swagger/tests/tests.py
+++ b/eve_swagger/tests/tests.py
@@ -1,0 +1,38 @@
+if __name__ == '__main__':
+    import sys
+    import os
+    import unittest
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                 '..', '..')))
+
+from eve_swagger.tests import TestBase
+
+class TestFoobar(TestBase):
+    def test_doc_is_dict(self):
+        doc = self.swagger_doc
+        self.assertIsInstance(doc, dict)
+
+    def test_info(self):
+        doc = self.swagger_doc
+
+        self.assertIn('info', doc)
+        self.assertIn('title', doc['info'])
+        self.assertIsInstance(doc['info']['title'], basestring)
+        self.assertIn('version', doc['info'])
+        self.assertIsInstance(doc['info']['version'], basestring)
+
+    def test_paths(self):
+        doc = self.swagger_doc
+
+        self.assertIn('paths', doc)
+        self.assertIn('/'+self.domain['people']['url'], doc['paths'])
+        self.assertIn('/%s/{%sId}' % (self.domain['people']['url'],
+                                      self.domain['people']['item_title'].lower()),
+                      doc['paths'])
+
+    def test_resource_description(self):
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/eve_swagger/tests/tests.py
+++ b/eve_swagger/tests/tests.py
@@ -1,7 +1,28 @@
-from eve_swagger.tests import TestBase
+import json
 
 
-class TestFoobar(TestBase):
+if __name__ == '__main__':
+    import sys
+    import os
+    import unittest
+    sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                 '..', '..')))
+
+from eve_swagger.tests import TestBase  # noqa: E402
+
+
+class TestEveSwagger(TestBase):
+    def test_api(self):
+        self.app.debug = True
+        r = self.test_client.get('/api-docs')
+        self.assertEqual(r.status_code, 200)
+
+    def test_json(self):
+        self.app.debug = True
+        r = self.test_client.get('/api-docs')
+        s = r.get_data().decode('utf-8')  # raises UnicodeError
+        json.loads(s)  # raises ValueError
+
     def test_doc_is_dict(self):
         doc = self.swagger_doc
         self.assertIsInstance(doc, dict)
@@ -17,13 +38,107 @@ class TestFoobar(TestBase):
 
     def test_paths(self):
         doc = self.swagger_doc
+        url = self.domain['people']['url']
+        item_title = self.domain['people']['item_title']
 
         self.assertIn('paths', doc)
-        self.assertIn('/'+self.domain['people']['url'], doc['paths'])
-        self.assertIn(
-            '/%s/{%sId}' % (self.domain['people']['url'],
-                            self.domain['people']['item_title'].lower()),
-            doc['paths'])
+        self.assertIsInstance(doc['paths'], dict)
+        self.assertIn('/'+url, doc['paths'])
+        self.assertIn('/%s/{%sId}' % (url, item_title.lower()), doc['paths'])
+
+    def test_definitions(self):
+        doc = self.swagger_doc
+        item_title = self.domain['people']['item_title']
+
+        self.assertIn('definitions', doc)
+        self.assertIsInstance(doc['definitions'], dict)
+        self.assertIn(item_title, doc['definitions'])
+        self.assertIn('properties', doc['definitions'][item_title])
+        self.assertEqual(
+            set(doc['definitions'][item_title]['properties'].keys()),
+            set(['name', 'job', '_id']))
+
+    def test_parameters_people(self):
+        doc = self.swagger_doc
+        item_title = self.domain['people']['item_title']
+        lookup_field = self.domain['people']['item_lookup_field']
+
+        self.assertIn('parameters', doc)
+        self.assertIn(item_title+'_'+lookup_field, doc['parameters'])
 
     def test_resource_description(self):
-        pass
+        doc = self.swagger_doc
+        item_title = self.domain['people']['item_title']
+
+        self.assertEqual('the people resource',
+                         doc['definitions'][item_title]['description'])
+
+    def test_field_description(self):
+        doc = self.swagger_doc
+        item_title = self.domain['people']['item_title']
+        props = doc['definitions'][item_title]['properties']
+
+        self.assertEqual('the last name of the person',
+                         props['name']['description'])
+
+    def test_disabled_resource(self):
+        doc = self.swagger_doc
+        url = self.domain['disabled_resource']['url']
+        item_title = self.domain['disabled_resource']['item_title']
+        lookup_field = self.domain['disabled_resource']['item_lookup_field']
+
+        self.assertNotIn('/'+url, doc['paths'])
+        self.assertNotIn('/%s/{%sId}' % (url, item_title.lower()),
+                         doc['paths'])
+        self.assertNotIn(item_title, doc['definitions'])
+        self.assertNotIn(item_title+'_'+lookup_field, doc['parameters'])
+
+    def test_data_relation_source_field(self):
+        doc = self.swagger_doc
+
+        source_field = self.domain['people']['item_title']+'_job'
+        self.assertIn(source_field, doc['definitions'])
+
+    def test_reference_to_data_relation_source_field(self):
+        doc = self.swagger_doc
+        people_it = self.domain['people']['item_title']
+        people_props = doc['definitions'][people_it]['properties']
+        dr_1_it = self.domain['dr_resource_1']['item_title']
+        dr_1_props = doc['definitions'][dr_1_it]['properties']
+        key = people_it + '_job'
+
+        self.assertIn('$ref', people_props['job'])
+        self.assertEqual('#/definitions/%s' % key,
+                         people_props['job']['$ref'])
+
+        self.assertIn('$ref', dr_1_props['copied_field_with_description'])
+        self.assertEqual('#/definitions/%s' % key,
+                         dr_1_props['copied_field_with_description']['$ref'])
+
+    def test_data_relation_extended_description(self):
+        doc = self.swagger_doc
+        item_title = self.domain['dr_resource_1']['item_title']
+        lookup_field = self.domain['dr_resource_1']['item_lookup_field']
+        par = doc['parameters'][item_title+'_'+lookup_field]
+        people_it = self.domain['people']['item_title']
+
+        self.assertIn('description', par)
+        self.assertEqual(
+            'foobar copied_field (links to {}_job)'.format(people_it),
+            par['description'])
+
+    def test_data_relation_copied_description(self):
+        doc = self.swagger_doc
+        item_title = self.domain['dr_resource_2']['item_title']
+        lookup_field = self.domain['dr_resource_2']['item_lookup_field']
+        par = doc['parameters'][item_title+'_'+lookup_field]
+        people_it = self.domain['people']['item_title']
+
+        self.assertIn('description', par)
+        self.assertEqual(
+            'the job of the person (links to {}_job)'.format(people_it),
+            par['description'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/eve_swagger/tests/tests.py
+++ b/eve_swagger/tests/tests.py
@@ -124,7 +124,7 @@ class TestEveSwagger(TestBase):
 
         self.assertIn('description', par)
         self.assertEqual(
-            'foobar copied_field (links to {}_job)'.format(people_it),
+            'foobar copied_field (links to {0}_job)'.format(people_it),
             par['description'])
 
     def test_data_relation_copied_description(self):
@@ -136,7 +136,7 @@ class TestEveSwagger(TestBase):
 
         self.assertIn('description', par)
         self.assertEqual(
-            'the job of the person (links to {}_job)'.format(people_it),
+            'the job of the person (links to {0}_job)'.format(people_it),
             par['description'])
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,9 @@ commands =
   - pylint --rcfile=tox.ini setup.py eve_swagger/
 
 [testenv:py26]
-deps = ordereddict, unittest2
+deps =
+    ordereddict
+    unittest2
 commands = unit2 discover -v -s eve_swagger/tests
 
 [testenv:py27]

--- a/tox.ini
+++ b/tox.ini
@@ -1,18 +1,21 @@
 [flake8]
 exclude = build,dist,reports,*.egg-info,.tox,.ropeproject
 
-[testenv:py26]
-deps=ordereddict
-
 [pylint]
 disable = locally-disabled
 output-format = colorized
 reports = no
 
 [tox]
+skip_missing_interpreters = True
 envlist =
     flake8
     # pylint
+    py26
+    py27
+    py33
+    py34
+    py35
 
 [testenv:flake8]
 deps = flake8
@@ -22,3 +25,19 @@ commands = flake8 setup.py eve_swagger
 deps = pylint
 commands =
   - pylint --rcfile=tox.ini setup.py eve_swagger/
+
+[testenv:py26]
+deps = ordereddict, unittest2
+commands = unit2 discover -v -s eve_swagger/tests
+
+[testenv:py27]
+commands = python -m unittest discover -v -s eve_swagger/tests
+
+[testenv:py33]
+commands = python -m unittest discover -v -s eve_swagger/tests
+
+[testenv:py34]
+commands = python -m unittest discover -v -s eve_swagger/tests
+
+[testenv:py35]
+commands = python -m unittest discover -v -s eve_swagger/tests


### PR DESCRIPTION
This PR adds a test suite to eve_swagger. I started out by looking at the test suites from Cerberus and Eve.
As I understood it from the already existing `setup.py` and `tox.ini`, the workflow is that setup.py calls tox, which then starts unittest for each environment. So by running `python setup.py test` you can test against all environments (if you have the necessary interpreter).

I added some tests that I thought were necessary, but I am sure there is still a lot missing.

On my machine I only have python 2.7 and 3.5, so I don't know (yet) if there are problems with the other tox environments.

This PR closes #8.
Feel free to criticize/suggest changes :)