### PR TITLE
Add CORS support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,10 @@ support with the ``X_DOMAINS`` and ``X_HEADERS`` configuration in your Eve
 
 .. code-block:: python
 
-    X_DOMAINS = 'http://localhost:8000'  # the domain where Swagger UI is running
+    X_DOMAINS = ['http://localhost:8000',  # The domain where Swagger UI is running
+                 'http://editor.swagger.io',
+                 'http://petstore.swagger.io']
+    X_HEADERS = ['Content-Type', 'If-Match']  # Needed for the "Try it out" buttons
 
 For more information check the CORS documentation of `Swagger UI`_ and `Swagger
 Editor`_.

--- a/README.rst
+++ b/README.rst
@@ -48,10 +48,22 @@ Usage
     if __name__ == '__main__':
         app.run()
 
-When API is up and running, visit the ``/api-docs`` endpoint. The resulting
-JSON can then be used with swagger tooling, like the Swagger Editor:
+When the API is up and running, visit the ``/api-docs`` endpoint. The resulting
+JSON can then be used with swagger tooling, like the Swagger UI or Swagger Editor:
 
 .. image:: resources/swagger_editor.png
+
+If you get the error "*Can't read from server. It may not have the appropriate
+access-control-origin settings*" from Swagger UI, you might want to enable CORS
+support with the ``X_DOMAINS`` and ``X_HEADERS`` configuration in your Eve
+``settings.py``:
+
+.. code-block:: python
+
+    X_DOMAINS = 'http://localhost:8000'  # the domain where Swagger UI is running
+
+For more information check the CORS documentation of `Swagger UI`_ and `Swagger
+Editor`_.
 
 Installation
 ------------
@@ -64,7 +76,7 @@ Description fields on the swagger docs
 --------------------------------------
 
 If you would like to include description fields to your swagger docs you can
-include a description field in your schema validations in your `settings.py`.
+include a description field in your schema validations in your ``settings.py``.
 This can be done per field as well as on the resource-level.
 
 As an example:
@@ -84,16 +96,16 @@ As an example:
     }
     ...
     
-**NOTE**: If you do use that feature make sure that the `TRANSPARENT_SCHEMA_RULES`
-in your `settings.py` is also turned ON, otherwise you will get complains from the
+**NOTE**: If you do use that feature make sure that the ``TRANSPARENT_SCHEMA_RULES``
+in your ``settings.py`` is also turned ON, otherwise you will get complains from the
 Cerberus library about "unknown field 'description' for field [yourFieldName]"
 
 Disabling the documentation of a resource
 -----------------------------------------
 
-You can disable the documentation of a specific resource by adding a `disable_documentation` field
-to the resource definition in `settings.py`. This means that the resource will not show up in
-the `paths` or `definitions` sections of the swagger docs.
+You can disable the documentation of a specific resource by adding a ``disable_documentation`` field
+to the resource definition in ``settings.py``. This means that the resource will not show up in
+the ``paths`` or ``definitions`` sections of the swagger docs.
 
 .. code-block:: python
 
@@ -166,3 +178,5 @@ See the original LICENSE_ for more informations.
 .. _`popular request`: https://github.com/nicolaiarocci/eve/issues/574
 .. _LICENSE: https://github.com/nicolaiarocci/eve-swagger/blob/master/LICENSE
 .. _`Nicola Iarocci`: http://nicolaiarocci.com
+.. _`Swagger UI`: https://github.com/swagger-api/swagger-ui#enabling-cors
+.. _`Swagger Editor`: https://github.com/swagger-api/swagger-editor/blob/master/docs/cors.md

--- a/eve_swagger/paths.py
+++ b/eve_swagger/paths.py
@@ -145,7 +145,9 @@ def put_response(rd):
                 'description': '%s document replaced successfully' % title
             }
         }),
-        ('parameters', [id_parameter(rd), get_parameters(rd)])
+        ('parameters', [id_parameter(rd),
+                        get_parameters(rd),
+                        header_parameters()])
     ])
 
 
@@ -158,7 +160,9 @@ def patch_response(rd):
                 'description': '%s document updated successfully' % title
             }
         }),
-        ('parameters', [id_parameter(rd), get_parameters(rd)])
+        ('parameters', [id_parameter(rd),
+                        get_parameters(rd),
+                        header_parameters()])
     ])
 
 
@@ -171,13 +175,23 @@ def deleteitem_response(rd):
                 'description': '%s document deleted successfully' % title
             }
         }),
-        ('parameters', [id_parameter(rd)])
+        ('parameters', [id_parameter(rd), header_parameters()])
     ])
 
 
 def id_parameter(rd):
     return {'$ref': '#/parameters/{0}_{1}'.format(rd['item_title'],
                                                   rd['item_lookup_field'])}
+
+
+def header_parameters():
+    r = OrderedDict()
+    r['in'] = 'header'
+    r['name'] = 'If-Match'
+    r['description'] = 'Current value of the _etag field'
+    r['required'] = True
+    r['type'] = 'string'
+    return r
 
 
 def _hook_descriptions(resource, method, item=False):

--- a/eve_swagger/tests/tests.py
+++ b/eve_swagger/tests/tests.py
@@ -139,6 +139,30 @@ class TestEveSwagger(TestBase):
             'the job of the person (links to {0}_job)'.format(people_it),
             par['description'])
 
+    def test_header_parameters(self):
+        doc = self.swagger_doc
+        url = self.domain['people']['url']
+        item_title = self.domain['people']['item_title']
+        url = '/%s/{%sId}' % (url, item_title.lower())
+
+        header_parameters = []
+        # assume that header parameters are equal for PUT, PATCH, and DELETE
+        for method in ['put', 'patch', 'delete']:
+            for p in doc['paths'][url][method]['parameters']:
+                if 'in' not in p:
+                    continue
+                if p['in'] == 'header':
+                    if method in ['patch', 'delete']:
+                        # already added in 'put'
+                        self.assertIn(p, header_parameters)
+                    else:
+                        header_parameters += [p]
+
+        self.assertTrue(len(header_parameters) == 1)
+        h = header_parameters[0]
+        self.assertIn('name', h)
+        self.assertEqual(h['name'], 'If-Match')
+
     def test_cors_without_origin(self):
         self.app.config['X_DOMAINS'] = ['http://example.com']
         self.app.config['X_HEADERS'] = ['Origin', 'X-Requested-With',


### PR DESCRIPTION
This PR enables CORS support to the `/api-docs` endpoint of eve_swagger by copying the settings from the parent Eve application.

This enables the use of Swagger UI or Swagger Editor running on a different domain (or just a different port) than the Eve app.
To enable CORS support, the user just has to add the Swagger UI domain to `X_DOMAINS`:

```python
app.config['X_DOMAINS'] = 'http://localhost:8000'
```

The [documentaion of Swagger UI ](https://github.com/swagger-api/swagger-ui#enabling-cors) mentions that it is also necessary to set some allowed headers. This would be done with the `X_HEADERS` setting, but for my API it was unnecessary.

This PR closes #11.