### PR TITLE
Handle missing fields and settings for Eve-Mongoengine

### DIFF
--- a/eve_swagger/objects.py
+++ b/eve_swagger/objects.py
@@ -73,6 +73,8 @@ def parameters():
 
         title = rd['item_title']
         lookup_field = rd['item_lookup_field']
+        if lookup_field not in rd['schema']:
+            rd['schema'][lookup_field] = {'type': 'objectid'}
         eve_type = rd['schema'][lookup_field]['type']
         descr = rd['schema'][lookup_field].get('description') or ''
         if 'data_relation' in rd['schema'][lookup_field]:

--- a/eve_swagger/swagger.py
+++ b/eve_swagger/swagger.py
@@ -38,11 +38,11 @@ def _modify_response(f):
             resp = make_response(f(*args, **kwargs))
 
         # CORS
-        domains = app.config['X_DOMAINS']
-        headers = app.config['X_HEADERS']
-        max_age = app.config['X_MAX_AGE']
-        allow_credentials = app.config['X_ALLOW_CREDENTIALS']
-        expose_headers = app.config['X_EXPOSE_HEADERS']
+        domains = app.config.get('X_DOMAINS')
+        headers = app.config.get('X_HEADERS')
+        max_age = app.config.get('X_MAX_AGE')
+        allow_credentials = app.config.get('X_ALLOW_CREDENTIALS')
+        expose_headers = app.config.get('X_EXPOSE_HEADERS')
         origin = request.headers.get('Origin')
         if origin and domains:
             if isinstance(domains, str):


### PR DESCRIPTION
This PR fixes #31.
Apparently Eve-Mongoengine is dead, so I modified Eve-Swagger to handle the missing schema for the `_id` field and `X_ALLOW_CREDENTIALS` settings.