### PR TITLE
Added support for data_relation nested in lists

### DIFF
--- a/eve_swagger/definitions.py
+++ b/eve_swagger/definitions.py
@@ -157,7 +157,11 @@ def _get_dr_sources(schema):
             title = app.config['DOMAIN'][dr['resource']]['item_title']
             def_name = title+'_'+dr['field']
             dr_sources[def_name] = None
-        elif 'schema' in rules and rules.get('type') == 'dict':
-            # recursively handle data_relations in subdicts
-            dr_sources.update(_get_dr_sources(rules['schema']))
+        elif 'schema' in rules:
+            if rules.get('type') in 'dict':
+                # recursively handle data_relations in subdicts
+                dr_sources.update(_get_dr_sources(rules['schema']))
+            elif rules.get('type') == 'list' and 'schema' in rules['schema']:
+                # recursively handle data_relations in lists
+                dr_sources.update(_get_dr_sources(rules['schema']['schema']))
     return dr_sources

--- a/eve_swagger/tests/test_settings.py
+++ b/eve_swagger/tests/test_settings.py
@@ -24,6 +24,25 @@ DOMAIN = {
                 'required': True,
                 'unique': True,
                 'description': 'the job of the person'
+            },
+            'relations': {
+                'type': 'list',
+                'schema': {
+                    'type': 'dict',
+                    'schema': {
+                        'relation_type': {
+                            'type': 'string',
+                            'required': True
+                        },
+                        'relation': {
+                            'type': 'objectid',
+                            'data_relation': {
+                                'resource': 'people',
+                                'field': '_id'
+                            }
+                        }
+                    }
+                }
             }
         }
     },

--- a/eve_swagger/tests/tests.py
+++ b/eve_swagger/tests/tests.py
@@ -56,7 +56,7 @@ class TestEveSwagger(TestBase):
         self.assertIn('properties', doc['definitions'][item_title])
         self.assertEqual(
             set(doc['definitions'][item_title]['properties'].keys()),
-            set(['name', 'job', '_id']))
+            set(['name', 'job', '_id', 'relations']))
 
     def test_parameters_people(self):
         doc = self.swagger_doc
@@ -110,10 +110,18 @@ class TestEveSwagger(TestBase):
         self.assertIn('$ref', people_props['job'])
         self.assertEqual('#/definitions/%s' % key,
                          people_props['job']['$ref'])
+        self.assertIn(key, doc['definitions'])
 
         self.assertIn('$ref', dr_1_props['copied_field_with_description'])
         self.assertEqual('#/definitions/%s' % key,
                          dr_1_props['copied_field_with_description']['$ref'])
+
+        key = people_it + '__id'
+        people_rels_props = people_props['relations']['items']['properties']
+        self.assertIn('$ref', people_rels_props['relation'])
+        self.assertEqual('#/definitions/%s' % key,
+                         people_rels_props['relation']['$ref'])
+        self.assertIn(key, doc['definitions'])
 
     def test_data_relation_extended_description(self):
         doc = self.swagger_doc


### PR DESCRIPTION
This PR adds support for `data_relations` nested in lists.

This resolves errors similar to the following one in the swagger editor:

```
 Swagger Error
Reference could not be resolved: #/definitions/deployment__id
Jump to line 543
Details
 Object
code:  "UNRESOLVABLE_REFERENCE"
message:  "Reference could not be resolved: #/definitions/deployment__id"
 path: Array [8]
error:  "JSON Pointer points to missing location: #/definitions/deployment__id"
level: 900
type:  "Swagger Error"
description:  "Reference could not be resolved: #/definitions/deployment__id"
lineNumber: 543
```

Best regards,
Patrick.