### PR TITLE
eve-swagger crashes if no docstring for hook is found

### DIFF
--- a/eve_swagger/paths.py
+++ b/eve_swagger/paths.py
@@ -271,7 +271,12 @@ def _hook_descriptions(resource, method, item=False):
         if len(callbacks) > 0:
             res += '\n* `' + e + '`:\n\n'
         for cb in callbacks:
-            s = '\n    '
-            s += '\n    '.join(dedent(cb.__doc__).strip().split('\n'))
-            res += '  * `' + cb.__name__ + '`:\n' + s + '\n\n'
+            if cb.__doc__:
+                s = '\n    '
+                s += '\n    '.join(dedent(cb.__doc__).strip().split('\n'))
+                res += '  * `' + cb.__name__ + '`:\n' + s + '\n\n'
+            else:
+                # there is no docstring provided, still add the hook name for
+                # information
+                res += '  * `' + cb.__name__ + '`:\nno documentation\n\n'
     return res


### PR DESCRIPTION
If there is no docstring provided for a hook function, eve swagger will crash because of this line

    s += '\n    '.join(dedent(cb.__doc__).strip().split('\n'))

where dedent cannot handle cb.__doc__ = None

In addition to the fix, I propose here to still document that the hook exists and simply add 'no documentation' as an indicator that there is no further documentation for the function found.