### PR TITLE
Additional openAPI fields

### DIFF
--- a/eve_swagger/definitions.py
+++ b/eve_swagger/definitions.py
@@ -112,6 +112,12 @@ def _field_props(rules, dr_sources, prefix):
         if eve_type in ['number', 'integer', 'float']:
             resp['maximum'] = rules['max']
 
+    if 'readonly' in rules:
+        resp['readOnly'] = rules['readonly']
+
+    if 'regex' in rules:
+        resp['pattern'] = rules['regex']
+
     type = map.get(eve_type, (eve_type,))
 
     resp['type'] = type[0]

--- a/eve_swagger/paths.py
+++ b/eve_swagger/paths.py
@@ -267,16 +267,20 @@ def _hook_descriptions(resource, method, item=False):
 
     res = ''
     for e in events:
+        event_doc = ''
+
         callbacks = getattr(app, e)
-        if len(callbacks) > 0:
-            res += '\n* `' + e + '`:\n\n'
         for cb in callbacks:
+            if cb.__name__ in app.config.get('HIDE_HOOK_FUNCTIONS', []):
+                continue
             if cb.__doc__:
-                s = '\n    '
-                s += '\n    '.join(dedent(cb.__doc__).strip().split('\n'))
-                res += '  * `' + cb.__name__ + '`:\n' + s + '\n\n'
+                s = '\n    '.join(dedent(cb.__doc__).strip().split('\n'))
+                event_doc += '  * `' + cb.__name__ + '`:\n' + s + '\n'
             else:
-                # there is no docstring provided, still add the hook name for
-                # information
-                res += '  * `' + cb.__name__ + '`:\nno documentation\n\n'
+                event_doc += '  * `' + cb.__name__ + '`:\nno documentation\n'
+
+        if len(event_doc) > 0:
+            # we actually documented some hooks
+            event_doc = '\n* `' + e + '`:\n' + event_doc
+        res += event_doc
     return res


### PR DESCRIPTION
the [swagger 2.0 or openAPI specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md) also supports `readOnly` (which is eve `readonly`) and `pattern` (which is eve/cerberus `regex`).

This pullrequest adds them to the eve-swagger output.

(However, `_id` will still not be reported as readonly as it is a datarelation and openAPI does not support `$ref` and `readOnly` together. The fix for this in my fork is that I don't report the id as a relation, but this is probably not the perfect way to go)