### PR TITLE
Additional openAPI fields

### DIFF
--- a/eve_swagger/definitions.py
+++ b/eve_swagger/definitions.py
@@ -112,6 +112,12 @@ def _field_props(rules, dr_sources, prefix):
         if eve_type in ['number', 'integer', 'float']:
             resp['maximum'] = rules['max']
 
+    if 'readonly' in rules:
+        resp['readOnly'] = rules['readonly']
+
+    if 'regex' in rules:
+        resp['pattern'] = rules['regex']
+
     type = map.get(eve_type, (eve_type,))
 
     resp['type'] = type[0]

--- a/eve_swagger/tests/test_settings.py
+++ b/eve_swagger/tests/test_settings.py
@@ -25,6 +25,15 @@ DOMAIN = {
                 'unique': True,
                 'description': 'the job of the person'
             },
+            'email': {
+                'type': 'string',
+                'required': True,
+                'regex': '^.+@.+$'
+            },
+            'position': {
+                'type': 'string',
+                'readonly': True
+            },
             'relations': {
                 'type': 'list',
                 'schema': {

--- a/eve_swagger/tests/tests.py
+++ b/eve_swagger/tests/tests.py
@@ -1,4 +1,5 @@
 import json
+from jsonschema import validate, ValidationError
 
 
 if __name__ == '__main__':
@@ -57,6 +58,17 @@ class TestEveSwagger(TestBase):
         self.assertEqual(
             set(doc['definitions'][item_title]['properties'].keys()),
             set(['name', 'job', 'email', 'position', '_id', 'relations']))
+
+    def test_definitions_are_jsonschema(self):
+        doc = self.swagger_doc
+        item_title = self.domain['people']['item_title']
+
+        # validate if schema is jsonschema
+        try:
+            validate({}, doc['definitions'][item_title])
+        except ValidationError:
+            # validation errors are only thrown after schema is checked
+            self.assertTrue(True)
 
     def test_parameters_people(self):
         doc = self.swagger_doc

--- a/eve_swagger/tests/tests.py
+++ b/eve_swagger/tests/tests.py
@@ -56,7 +56,7 @@ class TestEveSwagger(TestBase):
         self.assertIn('properties', doc['definitions'][item_title])
         self.assertEqual(
             set(doc['definitions'][item_title]['properties'].keys()),
-            set(['name', 'job', '_id', 'relations']))
+            set(['name', 'job', 'email', 'position', '_id', 'relations']))
 
     def test_parameters_people(self):
         doc = self.swagger_doc

--- a/tox.ini
+++ b/tox.ini
@@ -27,12 +27,12 @@ commands =
   - pylint --rcfile=tox.ini setup.py eve_swagger/
 
 [testenv]
-deps = jsonschema
+deps =
+    jsonschema
+    py26: ordereddict
+    py26: unittest2
 
 [testenv:py26]
-deps =
-    ordereddict
-    unittest2
 commands = unit2 discover -v -s eve_swagger/tests
 
 [testenv:py27]

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,9 @@ deps = pylint
 commands =
   - pylint --rcfile=tox.ini setup.py eve_swagger/
 
+[testenv]
+deps = jsonschema
+
 [testenv:py26]
 deps =
     ordereddict


### PR DESCRIPTION
the [swagger 2.0 or openAPI specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md) also supports `readOnly` (which is eve `readonly`) and `pattern` (which is eve/cerberus `regex`).

This pullrequest adds them to the eve-swagger output.

Concerning testing: As I understand eve-swagger tests right now actually don't test all of openAPIs validity. I therefore just added the new schema keys into the test-settings.

(However, `_id` will still not be reported as readonly as it is a datarelation and openAPI does not support `$ref` and `readOnly` together. The fix for this in my fork is that I don't report the id as a relation, but this is probably not the perfect way to go)